### PR TITLE
Fix return value for getPrefix()

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -133,6 +133,6 @@ class BEMWalkerNavMenu extends \Walker_Nav_Menu
             return '';
         }
 
-        return $this->getPrefix();
+        return $this->prefix . '-';
     }
 }


### PR DESCRIPTION
On return of this function getPrefix() is called causing an infinite loop and eventually a fatal PHP error due to the maximum number of nested items reached.

This returns the prefix and appends a hyphen. This may need to be tweaked to remove the hardcoded hyphen following the prefix. Note that if that happens the README should be updated so that users are aware they need to add their own seperator.